### PR TITLE
0.0.12 - Bug Fix: When executing command "Developer: Reload Window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [0.0.12]
+
+- Bug Fix: When executing command "Developer: Reload Window", the previous TCP port could not be reused because the old extension process was not kill. Now it saves the PID and kills it the next time the extension is activated.
+
 ## [0.0.11]
 
 - Bug Fix for `Access-Control-Allow-Origin: *` response header to allow calling VSCode REST Control from web browsers.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This extension allows you to remotely control Visual Studio Code via a REST endpoint, taking automation to the next level.",
   "publisher": "dpar39",
   "license": "MIT",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "engines": {
     "vscode": "^1.55.0"
   },


### PR DESCRIPTION
0.0.12 - Bug Fix: When executing command "Developer: Reload Window" the previous TCP port could not be reused because the old extension process was not kill. Now it saves the PID and kills it the next time the extension is activated.